### PR TITLE
feat: ランディングページの「ログイン」「始める」ボタンの機能を追加

### DIFF
--- a/src/components/landing/Header.tsx
+++ b/src/components/landing/Header.tsx
@@ -3,10 +3,20 @@
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { Menu, Code2, LogIn } from 'lucide-react';
+import { signIn, useSession } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
 
 export default function Header() {
   const [isOpen, setIsOpen] = useState(false);
+  const { data: session } = useSession();
+  const router = useRouter();
 
   const navigation = [
     { name: '機能', href: '#features' },
@@ -39,20 +49,57 @@ export default function Header() {
         </nav>
 
         <div className="flex items-center space-x-4">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="hidden md:flex items-center space-x-2 text-slate-600 hover:text-slate-900"
-          >
-            <LogIn className="h-4 w-4" />
-            <span>ログイン</span>
-          </Button>
-          <Button
-            size="sm"
-            className="bg-gradient-to-r from-slate-600 to-slate-800 hover:from-slate-700 hover:to-slate-900"
-          >
-            始める
-          </Button>
+          {/* Existing Login Button (Desktop) */}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="hidden md:flex items-center space-x-2 text-slate-600 hover:text-slate-900"
+              >
+                <LogIn className="h-4 w-4" />
+                <span>ログイン</span>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className="w-56">
+              <DropdownMenuItem onClick={() => signIn('google')}>
+                Googleでログイン
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => signIn('github', { callbackUrl: '/link-atcoder' })}>
+                GitHubでログイン
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          {/* "始める" Button (Desktop) - Modified */}
+          {session ? (
+            <Button
+              size="sm"
+              className="bg-gradient-to-r from-slate-600 to-slate-800 hover:from-slate-700 hover:to-slate-900"
+              onClick={() => router.push('/dashboard')}
+            >
+              始める
+            </Button>
+          ) : (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  size="sm"
+                  className="bg-gradient-to-r from-slate-600 to-slate-800 hover:from-slate-700 hover:to-slate-900"
+                >
+                  始める
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent className="w-56">
+                <DropdownMenuItem onClick={() => signIn('google')}>
+                  Googleで始める
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => signIn('github', { callbackUrl: '/link-atcoder' })}>
+                  GitHubで始める
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
 
           {/* Mobile Menu */}
           <Sheet open={isOpen} onOpenChange={setIsOpen}>
@@ -73,10 +120,36 @@ export default function Header() {
                     {item.name}
                   </a>
                 ))}
-                <Button variant="ghost" className="justify-start p-0 text-slate-600">
-                  <LogIn className="h-4 w-4 mr-2" />
-                  ログイン
-                </Button>
+                {/* Mobile Login Button - Modified */}
+                {session ? (
+                  <Button
+                    variant="ghost"
+                    className="justify-start p-0 text-slate-600"
+                    onClick={() => {
+                      router.push('/dashboard');
+                      setIsOpen(false);
+                    }}
+                  >
+                    始める
+                  </Button>
+                ) : (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="ghost" className="justify-start p-0 text-slate-600">
+                        <LogIn className="h-4 w-4 mr-2" />
+                        ログイン
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent className="w-56">
+                      <DropdownMenuItem onClick={() => signIn('google')}>
+                        Googleでログイン
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onClick={() => signIn('github', { callbackUrl: '/link-atcoder' })}>
+                        GitHubでログイン
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                )}
               </div>
             </SheetContent>
           </Sheet>


### PR DESCRIPTION
<img width="343" height="146" alt="スクリーンショット 2025-07-13 22 17 16" src="https://github.com/user-attachments/assets/ad181bfd-16bd-4e4d-90ca-d8c7c3f1925e" />

認証済みの場合始めるを押すとそのままダッシュボードに飛ばされる。
そうでない場合は添付したログインボタンと同じ挙動をする